### PR TITLE
feat: use separate collection card for collection page (related to #14)

### DIFF
--- a/src/assets/sass/objects/collection.scss
+++ b/src/assets/sass/objects/collection.scss
@@ -1,0 +1,42 @@
+.collection-card {
+  background-color: whitesmoke !important;
+  box-shadow: none !important;
+  -webkit-box-shadow: none !important;
+  border: 1px solid $coffee;
+
+  &__actions {
+    width: 50px;
+  }
+
+  &__children {
+    border-left: 1px solid $coffee;
+  }
+
+  .collection-card__head-border {
+    height: 10px;
+    width: 100%;
+    &__selected {
+      background-color: $primary !important;
+    }
+  }
+
+  &__title-input {
+    min-width: 420px;
+  }
+
+  &__dates {
+    line-height: 2rem;
+    white-space: nowrap;
+    font-weight: normal;
+    font-size: 1rem;
+    color: $brown;
+  }
+
+  .title {
+    font-size: 1.5rem;
+  }
+
+  .card-footer {
+    border-top: 1px solid $coffee;
+  }
+}

--- a/src/components/CollectionInteractiveCard.vue
+++ b/src/components/CollectionInteractiveCard.vue
@@ -109,7 +109,7 @@ import TitleFieldInPlace from "@/components/forms/fields/TitleFieldInPlace";
 import SaveButtonIcon from "@/components/ui/SaveButtonIcon";
 
 export default {
-  name: "CollectionCard",
+  name: "CollectionInteractiveCard",
   components: { TitleFieldInPlace, SaveButtonIcon },
   props: {
     collectionId: { type: String, required: true },
@@ -181,3 +181,4 @@ export default {
 @import "@/assets/sass/main.scss";
 @import "@/assets/sass/objects/collection.scss";
 </style>
+

--- a/src/pages/CollectionPage.vue
+++ b/src/pages/CollectionPage.vue
@@ -5,7 +5,7 @@
       Toutes les collections
     </router-link>
 
-    <collection-card :collection-id="String(collectionId)" :editable="true" class="m-3" />
+    <collection-interactive-card :collection-id="String(collectionId)" :editable="true" class="m-3" />
 
     <section>
       <span class="pagination-goto">
@@ -79,13 +79,13 @@
 </template>
 
 <script>
-import CollectionCard from "@/components/CollectionCard.vue";
+import CollectionInteractiveCard from "@/components/CollectionInteractiveCard.vue";
 import { mapActions } from "vuex";
 
 export default {
   name: "CollectionPage",
   components: {
-    CollectionCard,
+    CollectionInteractiveCard,
     DocumentTagBar: () => import("@/components/document/DocumentTagBar"),
     Document: () => import("@/components/sections/Document"),
   },


### PR DESCRIPTION
This MR introduces a separate card for a collection's page. At the moment it is the same as for the list of collections, the idea is to use this MR as an intermediate to decouple the two cards and be able to continue the developments on each independently.