### PR TITLE
reset document before setting the new dummy

### DIFF
--- a/src/store/modules/document/index.js
+++ b/src/store/modules/document/index.js
@@ -737,6 +737,7 @@ const actions = {
     return http.get(`collections/${collId}`).then(r => {
       const collection = r.data.data;
       const dummy = makeDummyDocument(defaultData);
+      this.dispatch('document/resetDocumentState');
       commit('UPDATE_DOCUMENT', {data: dummy.data, included: [collection]});
     });
   }


### PR DESCRIPTION
Make sure to reset the document state before creating the dummy one.

Closes #38