### PR TITLE
Amélioration de l'affichage des listes pour voir à quel document sont associés les détails

### DIFF
--- a/src/assets/sass/components/_search_results_table.scss
+++ b/src/assets/sass/components/_search_results_table.scss
@@ -9,16 +9,6 @@
     padding-top: 15px;
     overflow-x: inherit;
 
-    &.has-mobile-cards {
-      tr {
-        display: table-row !important;
-
-        &:not([class*="is-"]) {
-          background: transparent;
-        }
-      }
-    }
-
     table {
       width: 100% !important;
       border: none !important;
@@ -185,13 +175,11 @@
           }
 
           &:not(.detail) {
-            border-bottom: 1px solid #fdb3cc !important;
             box-shadow: none !important;
 
             td {
               display: table-cell !important;
               vertical-align: middle;
-              border-color: #fdb3cc !important;
               padding: 15px 15px 15px 0;
 
               font-family: $family-secondary;
@@ -576,6 +564,14 @@
   .locks-table .table-wrapper,
   .with-status .table-wrapper {
     table tbody {
+      tr {
+        &:not(.details-opened) {
+          border-bottom: 1px solid #fdb3cc;
+        }
+        td {
+          border: none;
+        }
+      }
       tr:not(.detail) {
 
         /* ID Lettre */
@@ -667,7 +663,11 @@
 
     tbody {
       tr {
+        &:not(.details-opened) {
+          border-bottom: 1px solid #fdb3cc;
+        }
         td {
+          border: none;
 
           /* Les colonnes des Lieux sont masquées en mode tableau */
           &:nth-child(7),
@@ -726,14 +726,9 @@
           "document-detail-toggle document-id document-date document-location-origin"
           "document-detail-toggle document-id document-date document-location-destination ";
 
-          border-bottom: 1px solid #fdb3cc;
           box-shadow: none !important;
           padding: 10px 0;
           margin: 0 !important;
-
-          &:last-child {
-            border: none;
-          }
 
           td {
             padding: 0 !important;
@@ -771,7 +766,6 @@
         tr.detail {
           width: 100%;
           box-shadow: none !important;
-          border-bottom: 1px solid #fdb3cc;
         }
       }
     }
@@ -795,14 +789,18 @@
   /* Version déplié */
   .is-inactive .table-wrapper {
 
-    table, tbody {
-      display: block;
-    }
-
     thead {
       display: none;
     }
     tbody {
+      tr {
+        &:not(.details-opened) {
+          border-bottom: 1px solid #fdb3cc;
+        }
+        td {
+          border: none;
+        }
+      }
 
       tr:not(.detail) {
         display: grid !important;
@@ -815,7 +813,6 @@
           "document-id document-recipients document-location-destination  document-detail-toggle";
 
         padding-top: 15px;
-        border-bottom: #CB2158 2px solid;
         border-top: none !important;
         box-shadow: none !important;
 
@@ -837,7 +834,6 @@
           display: block !important;
           width: 100%;
           min-width: 0;
-          border: none !important;
           padding: 0;
           text-align: left;
 
@@ -869,7 +865,6 @@
           &:nth-child(5),
           &:nth-child(7) {
             margin-top: 20px;
-            border-top: 1px solid #dbdbdb;
 
             @include on-small-tablet {
               margin-top: 0;
@@ -971,7 +966,6 @@
 
           /* Titre */
           &:nth-child(4) {
-            border-left: solid 6px #000000;
             max-width: 100% !important;
             padding-left: 20px;
 
@@ -1043,7 +1037,6 @@
       tr.detail {
         width: 100%;
         box-shadow: none !important;
-        border-bottom: 1px solid #fdb3cc;
       }
     }
   }

--- a/src/components/document/DocumentTagBar.vue
+++ b/src/components/document/DocumentTagBar.vue
@@ -190,14 +190,23 @@ export default {
         return Promise.resolve(false);
       });
     },
-    startLockEditor() {
+    async startLockEditor() {
       this.lockEditMode = true;
-      //await this.fetchStatus().then( (resp) => {
-        return Promise.resolve(this.status.currentLock['is-active']);
-      //})
+      await this.fetchStatus()
+      if (this.status.currentLock.id) {
+        this.lockUser = await this.fetchLockOwner({
+          docId: this.docId,
+          lockId: this.status.currentLock.id
+        })
+      }
+      await this.$store.dispatch("document/fetch", this.docId);
+
+
+      return Promise.resolve(this.status.currentLock['is-active']);
     },
     async stopLockEditor() {
       this.lockEditMode = false;
+      await this.$store.dispatch("document/fetch", this.docId);
       await this.fetchStatus().then( (resp) => {
         return Promise.resolve(this.status.currentLock['is-active']);
       })

--- a/src/components/forms/LockForm.vue
+++ b/src/components/forms/LockForm.vue
@@ -121,6 +121,7 @@ export default {
   },
   computed: {
     ...mapState("user", ["current_user", "users", "usersSearchResults", "jwt"]),
+
     nextLock() {
       if (this.nextLockOwner) {
         return {
@@ -191,6 +192,13 @@ export default {
     console.log('this.nextLockOwner (mounted) : ', this.nextLockOwner)
     this.description = this.defaultDescription;
   },
+  async created() {
+    if (this.current_user) {
+      if (this.current_user.isAdmin) {
+        await this.fetchUsers();
+      }
+    }
+  },
   methods: {
     ...mapActions("user", ["fetchUsers"]),
     ...mapActions("locks", ["saveLock", "updateLock"/*,"removeLock"*/]),
@@ -231,6 +239,7 @@ export default {
       }
     },
     searchUser(search) {
+      console.log("LockForm / searchUser", this.$store.dispatch("user/search", search))
       return this.$store.dispatch("user/search", search);
     },
     resetDescription() {

--- a/src/components/sections/Document.vue
+++ b/src/components/sections/Document.vue
@@ -930,6 +930,12 @@ export default {
     canEdit: function () {
       console.log("watch canEdit", this.canEdit)
     },
+    currentLock: async function (oldVal, newVal) {
+      console.log("currentLock updated ? :", oldVal, newVal)
+      if (!oldVal.id || !newVal.id || oldVal.attributes && oldVal.attributes.expiration_date == !newVal.attributes.expiration_date) {
+        //await this.load(this.docId);
+      }
+    }
   },
   beforeDestroy() {
     this.setViewerMode(undefined);

--- a/src/components/sections/DocumentList.vue
+++ b/src/components/sections/DocumentList.vue
@@ -388,19 +388,17 @@
         aria-previous-label="Page précédente"
         aria-page-label="Page"
         aria-current-label="Page courante"
-        :opened-detailed="[]"
         detailed
+        :opened-detailed="detailedRows"
         :backend-sorting="true"
         :sort-multiple="true"
         :sort-multiple-data="sortingPriority"
         detail-key="id"
         show-detail-icon
-
-
-        :row-class="(row, index) => showDetailIcon(row.id) === true ? '': 'hide-arrow-icon-detail'"
+        :row-class="rowClass"
 
         :narrowed="true"
-        :mobile-cards="true"
+        :mobile-cards="false"
         @sort="sortPressed"
         @sorting-priority-removed="sortingPriorityRemoved"
       >
@@ -733,6 +731,7 @@ export default {
       canEdit: false,
       //sortingPriority: [{field: 'creation', order: 'asc'}],
       tableData: [],
+      detailedRows: [],
       p: 1,
       isActive: true,
       isFulltext: true,
@@ -862,6 +861,16 @@ export default {
   methods: {
     //...mapState("search", ["documents"]),
     ...mapActions("search", ["setSearchTerm","setNumPage", "performSearch", "setSorts", "setSelectedCollections"]),
+    rowClass(row) {
+      let classNames = []
+      if (!this.showDetailIcon(row.id)) {
+        classNames.push('hide-arrow-icon-detail')
+      }
+      if (this.detailedRows.includes(row.id)) {
+        classNames.push("details-opened")
+      }
+      return classNames.join(" ")
+    },
     showDetailIcon(rowDocId) {
       let showIcon = false
       if (!this.loadingTable) {
@@ -1029,6 +1038,7 @@ export default {
             witnesses: d.witnesses,
           }
         }));
+        this.detailedRows = [];
       } else {
         this.tableData = await Promise.all(this.documents.map(async d => {
           return {
@@ -1044,6 +1054,7 @@ export default {
             witnesses: d.witnesses,
           }
         }));
+        this.detailedRows = [];
       }
       console.log("this.tableData : ", this.tableData)
       this.loadingTable = false

--- a/src/components/sections/DocumentListDetails.vue
+++ b/src/components/sections/DocumentListDetails.vue
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div
-      v-if="searchType === 'isParatextSearch' && witnesses && witnesses.length > 0"
+      v-if="(searchType === 'isParatextSearch' || !searchType) && witnesses && witnesses.length > 0"
     >
       <div class="heading">
         Témoins
@@ -55,7 +55,7 @@
       </div>
     </div>
     <mirador-viewer
-      v-if="searchType === 'isParatextSearch' && displayedManifestUrl"
+      v-if="(searchType === 'isParatextSearch' || !searchType) && displayedManifestUrl"
       class="mirador-container"
       :manifest-url="displayedManifestUrl"
       :window-id="documentId.toString()"
@@ -100,11 +100,15 @@ export default {
       displayedManifestUrl: undefined
     }
   },
+  created() {
+    console.log("this.witnesses ", this.$props.witnesses)
+  },
   computed: {
     ...mapState("search", ["searchTerm", "searchType"])
   },
   methods: {
     toggleMirador: function(newUrl) {
+      console.log("toggleMirador newUrl", newUrl)
       if (this.displayedManifestUrl === newUrl) {
         this.displayedManifestUrl = undefined
       } else {

--- a/src/pages/LocksPage.vue
+++ b/src/pages/LocksPage.vue
@@ -61,7 +61,7 @@
         aria-page-label="Page"
         aria-current-label="Page courante"
 
-        :opened-detailed="[]"
+        :opened-detailed="detailedRows"
         detailed
         :backend-sorting="true"
         :sort-multiple="true"
@@ -69,7 +69,7 @@
         detail-key="id"
         show-detail-icon
 
-        :row-class="(row, index) => showDetailIcon(row.id) === true ? '': 'hide-arrow-icon-detail'"
+        :row-class="rowClass"
 
         :debounce-search="1000"
 
@@ -390,6 +390,7 @@ export default {
       status: null,
       fetchedData: [],
       data: [],
+      detailedRows: [],
       filteredTags: [],
       documentsCollections: [],
       checkedRows:[],
@@ -474,6 +475,16 @@ export default {
     ...mapActions("user", ["fetchUsers"]),
     ...mapActions("search", ["setSearchType"]),
 
+    rowClass(row) {
+      let classNames = []
+      if (!this.showDetailIcon(row.id)) {
+        classNames.push('hide-arrow-icon-detail')
+      }
+      if (this.detailedRows.includes(row.id)) {
+        classNames.push("details-opened")
+      }
+      return classNames.join(" ")
+    },
     showDetailIcon(rowDocId) {
       let showIcon = false
       if (!this.loadingTable) {
@@ -671,6 +682,7 @@ export default {
             (this.numPage - 1) * this.pageSize,
             this.numPage * this.pageSize,
           )
+        this.detailedRows = [];
         //console.log('this.rootCollections : ', this.getCollectionAdmin());
         console.log('loadAsyncData() / this.data : ', this.data);
         this.isLoading = false;

--- a/src/pages/LocksPage.vue
+++ b/src/pages/LocksPage.vue
@@ -48,33 +48,39 @@
         ref="multiSortTable"
         class="locks-table"
         :data="data"
-        detailed
-        detail-key="object-id"
-        show-detail-icon
 
-        striped
         :loading="isLoading"
         backend-pagination
-        :current-page.sync="currentPage"
-        :per-page="pageSize"
         :total="totalCount"
+        :per-page="pageSize"
+        :current-page.sync="currentPage"
 
+
+        aria-next-label="Page suivante"
+        aria-previous-label="Page précédente"
+        aria-page-label="Page"
+        aria-current-label="Page courante"
+
+        :opened-detailed="[]"
+        detailed
         :backend-sorting="true"
         :sort-multiple="true"
         :sort-multiple-data="sortingPriority"
+        detail-key="id"
+        show-detail-icon
 
-        backend-filtering
+        :row-class="(row, index) => showDetailIcon(row.id) === true ? '': 'hide-arrow-icon-detail'"
+
         :debounce-search="1000"
 
         checkable
         checkbox-position="right"
         :checked-rows.sync="checkedRows"
-        :custom-is-checked="(a, b) => { return a['object-id'] === b['object-id'] }"
+        :custom-is-checked="(a, b) => { return a.id === b.id }"
 
         @sort="sortPressed"
+        backend-filtering
         @filters-change="onFilter"
-
-        @details-open="(row, index) => $buefy.toast.open(`Expanded ${row['object-id']}`)"
       >
         <template #bottom-left>
           <b>Total checked</b>: {{ checkedRows.length }}
@@ -87,19 +93,42 @@
           </section>
         </template>
         <template #detail="props">
-          <document
+          <document-list-details
+            :transcription-hightlight="props.row.transcriptionHightlight"
+            :argument="props.row.argument"
+            :witnesses="props.row.witnesses"
+            :document-id="props.row.id"
+          />
+          <!--<document
             class="document-page"
             :doc-id="props.row['object-id']"
             :preview="true"
-          />
+          />-->
         </template>
         <b-table-column
-          field="object-id"
+          field="id"
           label="Lettre"
           sortable
           numeric
           searchable
         >
+          <!--<template #searchable>
+            <b-taginput
+              v-model="tags"
+              :data="filteredTags"
+              autocomplete
+              icon="fas fa-search"
+              clearable
+              ellipsis
+              @typing="updateFilteredTags"
+              @icon-right-click="tags = ''"
+            >
+              <template #selected="props">
+                {{ props.tags }}
+              </template>
+            </b-taginput>
+         </template>-->
+
           <template v-slot:header="{ column }">
             <div v-if="column.sortable">
               <div v-if="sortingPriority.filter(obj => obj.field === column.field).length === 0">
@@ -127,8 +156,8 @@
           </template>
           <template #default="props">
             <document-tag-bar
-              :key="props.row['object-id']"
-              :doc-id="props.row['object-id']"
+              :key="props.row.id"
+              :doc-id="props.row.id"
               :with-status="true"
               :preview="true"
             />
@@ -136,7 +165,7 @@
         </b-table-column>
         <b-table-column
           field="collections"
-          label="Collection"
+          label="Collection(s)"
           sortable
           searchable
         >
@@ -245,7 +274,7 @@
           </template>
         </b-table-column>
         <b-table-column
-          field="event-date"
+          field="event_date"
           label="Date"
           sortable
           searchable
@@ -278,12 +307,12 @@
           <template #default="props">
             <span
               class="tag"
-              v-html="new Date(props.row['event-date']).toLocaleDateString()"
+              v-html="new Date(props.row.event_date).toLocaleDateString()"
             />
           </template>
         </b-table-column>
         <b-table-column
-          field="expiration-date"
+          field="expiration_date"
           label="Expire"
           sortable
           searchable
@@ -315,14 +344,14 @@
           </template>
           <template #default="props">
             <span
-              v-if="props.row['is-active']"
+              v-if="props.row.is_active"
               class="tag is-success"
-              v-html="new Date(props.row['expiration-date']).toLocaleDateString()"
+              v-html="new Date(props.row.expiration_date).toLocaleDateString()"
             />
             <span
               v-else
               class="tag is-warning"
-              v-html="new Date(props.row['expiration-date']).toLocaleDateString()"
+              v-html="new Date(props.row.expiration_date).toLocaleDateString()"
             />
           </template>
         </b-table-column>
@@ -344,14 +373,16 @@ import { mapState, mapActions, mapGetters } from "vuex";
 import DocumentTagBar from "@/components/document/DocumentTagBar";
 import LockForm from "@/components/forms/LockForm";
 import Document from "@/components/sections/Document.vue";
+import DocumentListDetails from "@/components/sections/DocumentListDetails.vue";
 
 export default {
   name: "LocksPage",
   components: {
-    Document,
+    DocumentListDetails,
+
     DocumentTagBar,
     LockForm
-  },
+  },//Document,
   data() {
     return {
       lockEditMode: false,
@@ -359,9 +390,10 @@ export default {
       status: null,
       fetchedData: [],
       data: [],
+      filteredTags: [],
       documentsCollections: [],
       checkedRows:[],
-      sortingPriority: [{ field: "expiration-date", order: "desc" }],
+      sortingPriority: [{ field: "expiration_date", order: "desc" }],
       filters: [],
       numPage: 1,
       p: 1,
@@ -370,7 +402,12 @@ export default {
       isLoading: false,
     };
   },
+
   computed: {
+    ...mapState("user", ["current_user", "jwt"]),
+    ...mapState("locks", ["fullLocks", "currentLock"]),
+    ...mapGetters("document", ["getDocumentStatus"]),
+
     totalPages: function() {
       return Math.ceil(this.totalCount / this.pageSize)
     },
@@ -387,9 +424,15 @@ export default {
         }
       },
     },
-    ...mapState("user", ["current_user", "jwt"]),
-    ...mapState("locks", ["fullLocks"]),
-    ...mapGetters("document", ["getDocumentStatus"])
+    tags: {
+      get: function () {
+          return [this.data.map(item => item.id)][0];
+      },
+      set: function (value) {
+        console.log("tags :", [this.data.filter(item => item.id.toString().includes(value)).map(item => item.id)])
+       return value;
+      }
+    }
   },
   watch: {
     checkedRows: async function() {
@@ -401,6 +444,13 @@ export default {
         this.withStatus = true;
       }
     },
+    currentLock: async function (newVal, oldVal) {
+      console.log("currentLock updated ? :", oldVal, newVal)
+      if (!oldVal || !newVal || oldVal.attributes.expiration_date ==! newVal.attributes.expiration_date ) {
+        await this.fetchData();
+        this.loadAsyncData()
+      }
+    }
     /*fetchData() {
       this.loadAsyncData();
     }*/
@@ -420,6 +470,26 @@ export default {
   methods: {
     ...mapActions("locks", ["fetchFullLocks"]),
     ...mapActions("user", ["fetchUsers"]),
+    showDetailIcon(rowDocId) {
+      let showIcon = false
+      if (!this.loadingTable) {
+        if (this.fullLocks && this.fullLocks.length <= 1 ) {
+          if (this.fullLocks[0].witnesses.length > 0 ) {
+            showIcon = true
+          }
+          return showIcon
+        } else {
+          if (this.fullLocks && this.fullLocks.filter(l => l.id === rowDocId)[0].witnesses.length > 0 ) {
+            showIcon = true
+          }
+          return showIcon
+        }
+      }
+    },
+    updateFilteredTags(text) {
+      this.filteredTags = [this.data.filter(item => item.id.toString().includes(text)).map(item => item.id)][0]
+      console.log("this.filteredTags :", this.filteredTags)
+    },
     async fetchStatus(docId) {
       this.status = await this.getDocumentStatus(docId);
       console.log("status", docId, this.status);
@@ -433,11 +503,11 @@ export default {
           // If username filter, get user_ids
           if (Object.keys(this.filters)[i] === 'username') {
             if (this.current_user.isAdmin) {
-              filtered_users = this.$store.state.user.users.map(u => u.username.toLowerCase().includes(Object.values(this.filters)[i].toLowerCase()) ? u.id : false).filter(Boolean);
+              filtered_users = this.$store.state.user.users.map(u => u.username.toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "").includes(Object.values(this.filters)[i].toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "")) ? u.id : false).filter(Boolean);
               console.log('filtered_users for admins: ', filtered_users)
               if (filtered_users.length > 0) {
                   // assign array of users as list (backend expects list)
-                  filters_list.push('filter[user_id]=[' + filtered_users + ']');
+                  filters_list.push({'user_id': filtered_users});
               } else {
                   this.fetchedData = [];
                   this.data = [];
@@ -446,14 +516,18 @@ export default {
               }
             }
           }
-          else filters_list.push('filter[' + Object.keys(this.filters)[i] + ']=' + Object.values(this.filters)[i]);
+          else {
+            let filters_payload = {};
+            filters_payload[Object.keys(this.filters)[i]] = Object.values(this.filters)[i]
+            filters_list.push(filters_payload);
+          }
         }
       }
       if (!this.current_user.isAdmin){
         console.log("For non-admin users, only fetch their own locks");
         filtered_users = [this.current_user.id]
         if (filtered_users.length > 0){
-          filters_list.push('filter[user_id]=[' + filtered_users + ']');
+          filters_list.push({'user_id': filtered_users});
         } else {
           this.data = [];
           this.isLoading = false;
@@ -502,7 +576,7 @@ export default {
           console.log(newPriority, this.sortingPriority);
       } else {
           // default sorting on descending locks expiration date
-          this.sortingPriority = [{ field: "expiration-date", order: "desc" }];
+          this.sortingPriority = [{ field: "expiration_date", order: "desc" }];
           console.log("Default sorting new Priority", newPriority, this.sortingPriority);
       }
       await this.fetchData();
@@ -590,7 +664,7 @@ export default {
         this.data = this.fetchedData.locksWithCollections
           // local pagination
           .slice(
-            (this.numPage- 1) * this.pageSize,
+            (this.numPage - 1) * this.pageSize,
             this.numPage * this.pageSize,
           )
         //console.log('this.rootCollections : ', this.getCollectionAdmin());
@@ -810,6 +884,39 @@ export default {
   ::v-deep {
     input[type=number] {
       -moz-appearance: textfield;
+    }
+  }
+
+  ::v-deep .b-table tr {
+      &:not(.hide-arrow-icon-detail) {
+        td.chevron-cell a {
+          width: 15px;
+          height: 15px;
+          span.icon {
+            &:after {
+              display: none !important;
+            }
+             &:not(.is-expanded) {
+               background: url(../assets/images/icons/open_text.svg) center / 15px auto no-repeat;
+             }
+             &.is-expanded {
+               background: url(../assets/images/icons/close_text.svg) center / 10px auto no-repeat;
+             }
+          }
+        }
+        &.hide-arrow-icon-detail {
+          width: 15px;
+          height: 15px;
+          span.icon:after {
+            display: none !important;
+          }
+        }
+      }
+  }
+  ::v-deep .b-table .hide-arrow-icon-detail td.chevron-cell a {
+    pointer-events: none;
+    span.icon:after {
+      display: none !important;
     }
   }
 </style>


### PR DESCRIPTION
Je me suis permis de me poser sur la branche locks. Autrement la page /locks fonctionnait mal. 


**Locks:**
![image](https://github.com/chartes/lettres-vue/assets/6593665/f44edb5e-901d-4f32-8d94-b80d748fab55)

**Search page - Tableau + PC:**
![image](https://github.com/chartes/lettres-vue/assets/6593665/59d39430-bd99-4002-9e1c-c8b7983e61c0)

**Page recherche - Tableau + mobile:**
![image](https://github.com/chartes/lettres-vue/assets/6593665/c1d6b7af-e516-4ac5-a1f0-7b46ca510058)

**Page recherche - Déplié + PC:**
![image](https://github.com/chartes/lettres-vue/assets/6593665/3e0fcdc6-ca4b-40cd-9c3e-27c07abb4225)

**Page recherche - Déplié + mobile :**
![image](https://github.com/chartes/lettres-vue/assets/6593665/f813aefb-3315-4c77-b8af-37a51c344294)

J'en profite pour laisser quelques remarques:
- Il y a beaucoup de CSS présent uniquement pour supprimer le style par défaut de buefy.
- On pourrait certainement simplifier le code css en utilisant https://tanstack.com/table/v8/docs/ qui fournit de la logique de gestion de tables (tri, pagination, expand/collpase) mais sans imposer de CSS.
- Pour la vue dépliée, on utilise également une table html alors que l'affichage est bien différent d'un tableau. Je pense qu'il serait plus simple de faire sans table, le CSS serait plus maintenable.


Closes #116.