### PR TITLE
fix: ensure that each mirador instance has its own namespace for classnames

### DIFF
--- a/src/components/MiradorViewer.vue
+++ b/src/components/MiradorViewer.vue
@@ -8,12 +8,15 @@
 
 <script>
 import React from 'react';
-import ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 import {Provider} from 'react-redux';
 import Mirador from "mirador";
 import MiradorApp from 'mirador/dist/es/src/components/App';
 import createPluggableStore from 'mirador/dist/es/src/state/createPluggableStore';
 import {mapActions, mapState} from "vuex";
+
+let NEXT_MUI_CLASSES_SEED = 0;
+
 
 export default {
   name: "MiradorViewer",
@@ -110,6 +113,11 @@ export default {
           },
           workspaceControlPanel: {
             enabled: false,
+          },
+          createGenerateClassNameOptions: {
+            productionPrefix: "mirador",
+            seed: NEXT_MUI_CLASSES_SEED++,
+
           }
         }
         this.reactRoot = ReactDOM.createRoot(document.getElementById(viewerContainerId));


### PR DESCRIPTION
 Mirador defines its styles as json and delegate classnames generation to the `@material-ui/core/styles` library. In production, the generated class names are deterministic and unique into a given `StylesContext`. Each mirador instance creates a new `StylesContext`, leading to classnames not being unique accross several Mirador instances.
Mirador exposes the MUI's `createGenerateClassNameOptions` which allows tweaking the generation of class names.
Here we add a unique prefix to every Mirador instances through the use of a counter.